### PR TITLE
[automated] automated: linux: ltp: skipfile: remove msgctl10,msgctl11,msgstress03,msgstress04

### DIFF
--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -212,7 +212,26 @@ skiplist:
       Test creates more than 3GB file which is time consuming so skipping.
     url: https://bugs.linaro.org/show_bug.cgi?id=3234
     environments: all
-    boards: *all_boards
+    boards:
+      - bcm2711-rpi-4-b
+      - dragonboard-410c
+      - dragonboard-845c
+      - e850-96
+      - hi6220-hikey-r2
+      - juno-r2
+      - qcom-qdf2400
+      - qrb5165-rb5
+      - x15
+      - x86
+      - qemu_arm
+      - qemu_arm64
+      - qemu_x86_64
+      - qemu_i386
+      - qemu-armv7
+      - qemu-x86_64
+      - qemu-i386
+      - fvp-aemva
+
     branches:
       - all
     tests:

--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -169,7 +169,26 @@ skiplist:
     url: https://bugs.linaro.org/show_bug.cgi?id=3720
     environments:
       - production
-    boards: *all_boards
+    boards:
+      - bcm2711-rpi-4-b
+      - dragonboard-410c
+      - dragonboard-845c
+      - e850-96
+      - hi6220-hikey-r2
+      - juno-r2
+      - qcom-qdf2400
+      - qrb5165-rb5
+      - x15
+      - x86
+      - qemu_arm
+      - qemu_arm64
+      - qemu_x86_64
+      - qemu_i386
+      - qemu-armv7
+      - qemu-x86_64
+      - qemu-i386
+      - fvp-aemva
+
     branches: all
     tests:
       - gf01

--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -125,7 +125,26 @@ skiplist:
       x86: ltp sched tests hang due to NFS not responding
     url: https://bugs.linaro.org/show_bug.cgi?id=3338
     environments: all
-    boards: *all_boards
+    boards:
+      - bcm2711-rpi-4-b
+      - dragonboard-410c
+      - dragonboard-845c
+      - e850-96
+      - hi6220-hikey-r2
+      - juno-r2
+      - qcom-qdf2400
+      - qrb5165-rb5
+      - x15
+      - x86
+      - qemu_arm
+      - qemu_arm64
+      - qemu_x86_64
+      - qemu_i386
+      - qemu-armv7
+      - qemu-x86_64
+      - qemu-i386
+      - fvp-aemva
+
     branches: all
     tests:
       - pth_str01

--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -219,7 +219,26 @@ skiplist:
       memory (specially ones having short memory)
     url: https://bugs.linaro.org/show_bug.cgi?id=4023
     environments: production
-    boards: *all_boards
+    boards:
+      - bcm2711-rpi-4-b
+      - dragonboard-410c
+      - dragonboard-845c
+      - e850-96
+      - hi6220-hikey-r2
+      - juno-r2
+      - qcom-qdf2400
+      - qrb5165-rb5
+      - x15
+      - x86
+      - qemu_arm
+      - qemu_arm64
+      - qemu_x86_64
+      - qemu_i386
+      - qemu-armv7
+      - qemu-x86_64
+      - qemu-i386
+      - fvp-aemva
+
     branches:
       - all
     tests:

--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -311,7 +311,26 @@ skiplist:
       LTP tracing test case ftrace_stress_test.sh crashing on all devices.
     url: https://bugs.linaro.org/show_bug.cgi?id=5722
     environments: production
-    boards: *all_boards
+    boards:
+      - bcm2711-rpi-4-b
+      - dragonboard-410c
+      - dragonboard-845c
+      - e850-96
+      - hi6220-hikey-r2
+      - juno-r2
+      - qcom-qdf2400
+      - qrb5165-rb5
+      - x15
+      - x86
+      - qemu_arm
+      - qemu_arm64
+      - qemu_x86_64
+      - qemu_i386
+      - qemu-armv7
+      - qemu-x86_64
+      - qemu-i386
+      - fvp-aemva
+
     branches:
       - all
     tests:

--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -59,7 +59,26 @@ skiplist:
       LTP: msgctl10 fork failed
     url: https://bugs.linaro.org/show_bug.cgi?id=2355
     environments: all
-    boards: *all_boards
+    boards:
+      - bcm2711-rpi-4-b
+      - dragonboard-410c
+      - dragonboard-845c
+      - e850-96
+      - hi6220-hikey-r2
+      - juno-r2
+      - qcom-qdf2400
+      - qrb5165-rb5
+      - x15
+      - x86
+      - qemu_arm
+      - qemu_arm64
+      - qemu_x86_64
+      - qemu_i386
+      - qemu-armv7
+      - qemu-x86_64
+      - qemu-i386
+      - fvp-aemva
+
     branches: all
     tests:
       - msgctl10

--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -23,25 +23,25 @@ globals:
 # This list represents the devices in the lab from lkft.validation.linaro.org,
 # and the qemu devices available in tuxsuite.
   - boards: &all_boards
-    - bcm2711-rpi-4-b
-    - dragonboard-410c
-    - dragonboard-845c
-    - e850-96
-    - hi6220-hikey-r2
-    - juno-r2
-    - qcom-qdf2400
-    - qrb5165-rb5
-    - x15
-    - x86
-    - qemu_arm
-    - qemu_arm64
-    - qemu_x86_64
-    - qemu_i386
-    - qemu-armv7
-    - qemu-arm64
-    - qemu-x86_64
-    - qemu-i386
-    - fvp-aemva
+      - bcm2711-rpi-4-b
+      - dragonboard-410c
+      - dragonboard-845c
+      - e850-96
+      - hi6220-hikey-r2
+      - juno-r2
+      - qcom-qdf2400
+      - qrb5165-rb5
+      - x15
+      - x86
+      - qemu_arm
+      - qemu_arm64
+      - qemu_x86_64
+      - qemu_i386
+      - qemu-armv7
+      - qemu-arm64
+      - qemu-x86_64
+      - qemu-i386
+      - fvp-aemva
 
 skiplist:
   - reason: >

--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -360,7 +360,26 @@ skiplist:
       which need full ping commmand in OE rootfs.
     url: https://bugs.linaro.org/show_bug.cgi?id=5792
     environments: production
-    boards: *all_boards
+    boards:
+      - bcm2711-rpi-4-b
+      - dragonboard-410c
+      - dragonboard-845c
+      - e850-96
+      - hi6220-hikey-r2
+      - juno-r2
+      - qcom-qdf2400
+      - qrb5165-rb5
+      - x15
+      - x86
+      - qemu_arm
+      - qemu_arm64
+      - qemu_x86_64
+      - qemu_i386
+      - qemu-armv7
+      - qemu-x86_64
+      - qemu-i386
+      - fvp-aemva
+
     branches:
       - all
     tests:

--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -223,7 +223,26 @@ skiplist:
       Board doesn't have enough memory to run the test (1GB)
     url: https://bugs.linaro.org/show_bug.cgi?id=4272
     environments: production
-    boards: *all_boards
+    boards:
+      - bcm2711-rpi-4-b
+      - dragonboard-410c
+      - dragonboard-845c
+      - e850-96
+      - hi6220-hikey-r2
+      - juno-r2
+      - qcom-qdf2400
+      - qrb5165-rb5
+      - x15
+      - x86
+      - qemu_arm
+      - qemu_arm64
+      - qemu_x86_64
+      - qemu_i386
+      - qemu-armv7
+      - qemu-x86_64
+      - qemu-i386
+      - fvp-aemva
+
     branches:
       - all
     tests:

--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -249,7 +249,26 @@ skiplist:
       intermittent failure
     url: https://bugs.linaro.org/show_bug.cgi?id=4273
     environments: all
-    boards: *all_boards
+    boards:
+      - bcm2711-rpi-4-b
+      - dragonboard-410c
+      - dragonboard-845c
+      - e850-96
+      - hi6220-hikey-r2
+      - juno-r2
+      - qcom-qdf2400
+      - qrb5165-rb5
+      - x15
+      - x86
+      - qemu_arm
+      - qemu_arm64
+      - qemu_x86_64
+      - qemu_i386
+      - qemu-armv7
+      - qemu-x86_64
+      - qemu-i386
+      - fvp-aemva
+
     branches:
       - all
     tests:


### PR DESCRIPTION
[automated] Updates to skipfile to remove:

- msgctl10
- msgctl11
- msgstress03
- msgstress04.

Test were shown to pass/fail rather than hang do not need to be skipped.

Remove for devices:

- qemu-arm64
- qemu-arm64
- qemu-arm64
- qemu-arm64
- qemu-arm64
- qemu-arm64
- qemu-arm64
- qemu-arm64
- qemu-arm64

Tests run 1 time(s).

Tested on:

- qemu-arm64: f7dc24b3413851109c4047b22997bd0d95ed52a2
