### PR TITLE
[automated] automated: linux: ltp: skipfile: remove sendfile09,sendfile09_64

### DIFF
--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -174,7 +174,26 @@ skiplist:
       Test creates more than 3GB file which is time consuming so skipping.
     url: https://bugs.linaro.org/show_bug.cgi?id=3234
     environments: all
-    boards: *all_boards
+    boards:
+      - bcm2711-rpi-4-b
+      - dragonboard-410c
+      - dragonboard-845c
+      - e850-96
+      - hi6220-hikey-r2
+      - juno-r2
+      - qcom-qdf2400
+      - qrb5165-rb5
+      - x15
+      - x86
+      - qemu_arm
+      - qemu_arm64
+      - qemu_x86_64
+      - qemu_i386
+      - qemu-armv7
+      - qemu-arm64
+      - qemu-i386
+      - fvp-aemva
+
     branches:
       - all
     tests:

--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -23,25 +23,25 @@ globals:
 # This list represents the devices in the lab from lkft.validation.linaro.org,
 # and the qemu devices available in tuxsuite.
   - boards: &all_boards
-    - bcm2711-rpi-4-b
-    - dragonboard-410c
-    - dragonboard-845c
-    - e850-96
-    - hi6220-hikey-r2
-    - juno-r2
-    - qcom-qdf2400
-    - qrb5165-rb5
-    - x15
-    - x86
-    - qemu_arm
-    - qemu_arm64
-    - qemu_x86_64
-    - qemu_i386
-    - qemu-armv7
-    - qemu-arm64
-    - qemu-x86_64
-    - qemu-i386
-    - fvp-aemva
+      - bcm2711-rpi-4-b
+      - dragonboard-410c
+      - dragonboard-845c
+      - e850-96
+      - hi6220-hikey-r2
+      - juno-r2
+      - qcom-qdf2400
+      - qrb5165-rb5
+      - x15
+      - x86
+      - qemu_arm
+      - qemu_arm64
+      - qemu_x86_64
+      - qemu_i386
+      - qemu-armv7
+      - qemu-arm64
+      - qemu-x86_64
+      - qemu-i386
+      - fvp-aemva
 
 skiplist:
   - reason: >


### PR DESCRIPTION
[automated] Updates to skipfile to remove:

- sendfile09
- sendfile09_64

Test were shown to pass/fail rather than hang do not need to be skipped.

Remove for devices:

- qemu-arm64
- qemu-x86_64

Tests run 2 time(s).

Tested on:

- qemu-arm64: f7dc24b3413851109c4047b22997bd0d95ed52a2
- qemu-x86_64: f7dc24b3413851109c4047b22997bd0d95ed52a2