### PR TITLE
[automated] automated: linux: ltp: skipfile: remove pth_str01,pth_str02,pth_str03,time-schedule01

### DIFF
--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -96,7 +96,6 @@ skiplist:
       - qemu_i386
       - qemu-armv7
       - qemu-arm64
-      - qemu-x86_64
       - qemu-i386
       - fvp-aemva
 
@@ -240,7 +239,6 @@ skiplist:
       - qemu_arm64
       - qemu_x86_64
       - qemu_i386
-      - qemu-armv7
       - qemu-arm64
       - qemu-x86_64
       - qemu-i386
@@ -274,9 +272,7 @@ skiplist:
       - qemu_arm64
       - qemu_x86_64
       - qemu_i386
-      - qemu-armv7
       - qemu-arm64
-      - qemu-x86_64
       - qemu-i386
       - fvp-aemva
 
@@ -369,10 +365,6 @@ skiplist:
       - qemu_arm64
       - qemu_x86_64
       - qemu_i386
-      - qemu-armv7
-      - qemu-arm64
-      - qemu-x86_64
-      - qemu-i386
       - fvp-aemva
 
     branches:
@@ -415,9 +407,7 @@ skiplist:
       - qemu_arm64
       - qemu_x86_64
       - qemu_i386
-      - qemu-armv7
       - qemu-arm64
-      - qemu-x86_64
       - qemu-i386
       - fvp-aemva
 
@@ -448,7 +438,6 @@ skiplist:
       - qemu_i386
       - qemu-armv7
       - qemu-arm64
-      - qemu-x86_64
       - qemu-i386
       - fvp-aemva
 
@@ -508,8 +497,6 @@ skiplist:
       - qemu_arm64
       - qemu_x86_64
       - qemu_i386
-      - qemu-armv7
-      - qemu-arm64
       - qemu-x86_64
       - qemu-i386
       - fvp-aemva
@@ -550,7 +537,6 @@ skiplist:
       - qemu_i386
       - qemu-armv7
       - qemu-arm64
-      - qemu-x86_64
       - qemu-i386
       - fvp-aemva
 
@@ -649,7 +635,6 @@ skiplist:
       - qemu_i386
       - qemu-armv7
       - qemu-arm64
-      - qemu-x86_64
       - qemu-i386
       - fvp-aemva
 
@@ -678,9 +663,6 @@ skiplist:
       - qemu_arm64
       - qemu_x86_64
       - qemu_i386
-      - qemu-armv7
-      - qemu-arm64
-      - qemu-x86_64
       - qemu-i386
       - fvp-aemva
 


### PR DESCRIPTION
[automated] Updates to skipfile to remove:

- pth_str01
- pth_str02
- pth_str03
- time-schedule01

Test were shown to pass/fail rather than hang do not need to be skipped.

Remove for devices:

- qemu-armv7

Tests run 10 time(s) per device.

Tested on:

- linux-next-master: qemu-armv7, SHA: 47762f08697484cf0c2f2904b8c52375ed26c8cb
- linux-next-master: qemu-arm64, SHA: 47762f08697484cf0c2f2904b8c52375ed26c8cb
- linux-next-master: qemu-i386, SHA: 56585460cc2ec44fc5d66924f0a116f57080f0dc
- linux-next-master: qemu-x86_64, SHA: 56585460cc2ec44fc5d66924f0a116f57080f0dc
- linux-stable-rc-linux-4.14.y: qemu-armv7, SHA: 01b341fdf42fdb882da5960db0b2cf5e59bd8bbb
- linux-stable-rc-linux-4.14.y: qemu-arm64, SHA: 01b341fdf42fdb882da5960db0b2cf5e59bd8bbb
- linux-stable-rc-linux-4.14.y: qemu-i386, SHA: 01b341fdf42fdb882da5960db0b2cf5e59bd8bbb
- linux-stable-rc-linux-4.14.y: qemu-x86_64, SHA: 01b341fdf42fdb882da5960db0b2cf5e59bd8bbb
- linux-stable-rc-linux-4.19.y: qemu-armv7, SHA: 82744209cce2a23e33a703b093c943754d955542
- linux-stable-rc-linux-4.19.y: qemu-arm64, SHA: a291d82603f3070dd8d1a940750eea9f477d1112
- linux-stable-rc-linux-4.19.y: qemu-i386, SHA: a291d82603f3070dd8d1a940750eea9f477d1112
- linux-stable-rc-linux-4.19.y: qemu-x86_64, SHA: a291d82603f3070dd8d1a940750eea9f477d1112
- linux-stable-rc-linux-5.10.y: qemu-armv7, SHA: c40f751018f92a4de17117a9018b24e538e55b50
- linux-stable-rc-linux-5.10.y: qemu-arm64, SHA: c40f751018f92a4de17117a9018b24e538e55b50
- linux-stable-rc-linux-5.10.y: qemu-i386, SHA: c40f751018f92a4de17117a9018b24e538e55b50
- linux-stable-rc-linux-5.10.y: qemu-x86_64, SHA: c40f751018f92a4de17117a9018b24e538e55b50
- linux-stable-rc-linux-5.15.y: qemu-armv7, SHA: 948d61e1588b9442fe7390e694431478159553bc
- linux-stable-rc-linux-5.15.y: qemu-arm64, SHA: 948d61e1588b9442fe7390e694431478159553bc
- linux-stable-rc-linux-5.15.y: qemu-i386, SHA: 948d61e1588b9442fe7390e694431478159553bc
- linux-stable-rc-linux-5.15.y: qemu-x86_64, SHA: 948d61e1588b9442fe7390e694431478159553bc
- linux-stable-rc-linux-6.1.y: qemu-armv7, SHA: 1aa86af84d82ad518de80697bddd58a9df5dee09
- linux-stable-rc-linux-6.1.y: qemu-arm64, SHA: 1aa86af84d82ad518de80697bddd58a9df5dee09
- linux-stable-rc-linux-6.1.y: qemu-i386, SHA: 1aa86af84d82ad518de80697bddd58a9df5dee09
- linux-stable-rc-linux-6.1.y: qemu-x86_64, SHA: 1aa86af84d82ad518de80697bddd58a9df5dee09