### PR TITLE
[automated] automated: linux: ltp: skipfile: remove sendfile09,sendfile09_64

### DIFF
--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -369,9 +369,7 @@ skiplist:
       - qemu_arm64
       - qemu_x86_64
       - qemu_i386
-      - qemu-armv7
       - qemu-arm64
-      - qemu-x86_64
       - qemu-i386
       - fvp-aemva
 


### PR DESCRIPTION
[automated] Updates to skipfile to remove:

- sendfile09
- sendfile09_64

Test were shown to pass/fail rather than hang do not need to be skipped.

Remove for devices:

- qemu-x86_64
- qemu-armv7

Tests run 10 time(s) per device.

Tested on:

- linux-next-master: qemu-armv7, git desc: next-20230817
- linux-next-master: qemu-arm64, git desc: next-20230817
- linux-next-master: qemu-i386, git desc: next-20230830
- linux-next-master: qemu-x86_64, git desc: next-20230830
- linux-stable-rc-linux-4.14.y: qemu-armv7, git desc: v4.14.323-58-g01b341fdf42f
- linux-stable-rc-linux-4.14.y: qemu-arm64, git desc: v4.14.323-58-g01b341fdf42f
- linux-stable-rc-linux-4.14.y: qemu-i386, git desc: v4.14.323-58-g01b341fdf42f
- linux-stable-rc-linux-4.14.y: qemu-x86_64, git desc: v4.14.323-58-g01b341fdf42f
- linux-stable-rc-linux-4.19.y: qemu-armv7, git desc: v4.19.292-79-g82744209cce2
- linux-stable-rc-linux-4.19.y: qemu-arm64, git desc: v4.19.292-130-ga291d82603f3
- linux-stable-rc-linux-4.19.y: qemu-i386, git desc: v4.19.292-130-ga291d82603f3
- linux-stable-rc-linux-4.19.y: qemu-x86_64, git desc: v4.19.292-130-ga291d82603f3
- linux-stable-rc-linux-5.10.y: qemu-armv7, git desc: v5.10.192-85-gc40f751018f9
- linux-stable-rc-linux-5.10.y: qemu-arm64, git desc: v5.10.192-85-gc40f751018f9
- linux-stable-rc-linux-5.10.y: qemu-i386, git desc: v5.10.192-85-gc40f751018f9
- linux-stable-rc-linux-5.10.y: qemu-x86_64, git desc: v5.10.192-85-gc40f751018f9
- linux-stable-rc-linux-5.15.y: qemu-armv7, git desc: v5.15.128-90-g948d61e1588b
- linux-stable-rc-linux-5.15.y: qemu-arm64, git desc: v5.15.128-90-g948d61e1588b
- linux-stable-rc-linux-5.15.y: qemu-i386, git desc: v5.15.128-90-g948d61e1588b
- linux-stable-rc-linux-5.15.y: qemu-x86_64, git desc: v5.15.128-90-g948d61e1588b
- linux-stable-rc-linux-6.1.y: qemu-armv7, git desc: v6.1.48-128-g1aa86af84d82
- linux-stable-rc-linux-6.1.y: qemu-arm64, git desc: v6.1.48-128-g1aa86af84d82
- linux-stable-rc-linux-6.1.y: qemu-i386, git desc: v6.1.48-128-g1aa86af84d82
- linux-stable-rc-linux-6.1.y: qemu-x86_64, git desc: v6.1.48-128-g1aa86af84d82