### PR TITLE
[automated] automated: linux: ltp: skipfile: remove sendfile09,sendfile09_64

### DIFF
--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -369,10 +369,6 @@ skiplist:
       - qemu_arm64
       - qemu_x86_64
       - qemu_i386
-      - qemu-armv7
-      - qemu-arm64
-      - qemu-x86_64
-      - qemu-i386
       - fvp-aemva
 
     branches:


### PR DESCRIPTION
[automated] Updates to skipfile to remove:

- sendfile09
- sendfile09_64

Test were shown to pass/fail rather than hang do not need to be skipped.

Remove for devices:

- qemu-i386
- qemu-armv7
- qemu-arm64
- qemu-x86_64

Tests run 10 time(s) per device.

Tested on:

- linux-next-master: qemu-armv7, git desc: next-20230817
- linux-next-master: qemu-arm64, git desc: next-20230817
- linux-next-master: qemu-i386, git desc: next-20230831
- linux-next-master: qemu-x86_64, git desc: next-20230831
- linux-mainline-master: qemu-armv7, git desc: v6.5-rc6-36-g4853c74bd7ab
- linux-mainline-master: qemu-arm64, git desc: v6.5-rc6-36-g4853c74bd7ab
- linux-mainline-master: qemu-i386, git desc: v6.5-11329-g708283abf896
- linux-mainline-master: qemu-x86_64, git desc: v6.5-11329-g708283abf896
- linux-stable-rc-linux-4.14.y: qemu-armv7, git desc: v4.14.325
- linux-stable-rc-linux-4.14.y: qemu-arm64, git desc: v4.14.325
- linux-stable-rc-linux-4.14.y: qemu-i386, git desc: v4.14.325
- linux-stable-rc-linux-4.14.y: qemu-x86_64, git desc: v4.14.325
- linux-stable-rc-linux-4.19.y: qemu-armv7, git desc: v4.19.294
- linux-stable-rc-linux-4.19.y: qemu-arm64, git desc: v4.19.294
- linux-stable-rc-linux-4.19.y: qemu-i386, git desc: v4.19.294
- linux-stable-rc-linux-4.19.y: qemu-x86_64, git desc: v4.19.294
- linux-stable-rc-linux-5.10.y: qemu-armv7, git desc: v5.10.194
- linux-stable-rc-linux-5.10.y: qemu-arm64, git desc: v5.10.194
- linux-stable-rc-linux-5.10.y: qemu-i386, git desc: v5.10.194
- linux-stable-rc-linux-5.10.y: qemu-x86_64, git desc: v5.10.194
- linux-stable-rc-linux-5.15.y: qemu-armv7, git desc: v5.15.130
- linux-stable-rc-linux-5.15.y: qemu-arm64, git desc: v5.15.130
- linux-stable-rc-linux-5.15.y: qemu-i386, git desc: v5.15.130
- linux-stable-rc-linux-5.15.y: qemu-x86_64, git desc: v5.15.130
- linux-stable-rc-linux-6.1.y: qemu-armv7, git desc: v6.1.51
- linux-stable-rc-linux-6.1.y: qemu-arm64, git desc: v6.1.51
- linux-stable-rc-linux-6.1.y: qemu-i386, git desc: v6.1.51
- linux-stable-rc-linux-6.1.y: qemu-x86_64, git desc: v6.1.51