### PR TITLE
[automated] automated: linux: ltp: skipfile: remove bind06,cve-2018-18559

SQUAD build URLs:
- https://qa-reports.linaro.org/api/builds/163487/
- https://qa-reports.linaro.org/api/builds/163488/
- https://qa-reports.linaro.org/api/builds/163489/
- https://qa-reports.linaro.org/api/builds/163490/
- https://qa-reports.linaro.org/api/builds/163491/
- https://qa-reports.linaro.org/api/builds/163492/
- https://qa-reports.linaro.org/api/builds/163493/

### DIFF
--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -619,7 +619,6 @@ skiplist:
       - qemu-armv7
       - qemu-arm64
       - qemu-x86_64
-      - qemu-i386
       - fvp-aemva
 
     branches:


### PR DESCRIPTION
[automated] Updates to skipfile to remove:

- bind06
- cve-2018-18559

Test were shown to pass/fail rather than hang do not need to be skipped.

Remove for devices:

- qemu-i386

Tests run 1 time(s) per device.

Tested on:

- linux-next-master: qemu-armv7, git desc: next-20230817
- linux-next-master: qemu-arm64, git desc: next-20230817
- linux-next-master: qemu-i386, git desc: next-20230913
- linux-next-master: qemu-x86_64, git desc: next-20230913
- linux-mainline-master: qemu-armv7, git desc: v6.5-rc6-36-g4853c74bd7ab
- linux-mainline-master: qemu-arm64, git desc: v6.5-rc6-36-g4853c74bd7ab
- linux-mainline-master: qemu-i386, git desc: v6.6-rc1-33-g3669558bdf35
- linux-mainline-master: qemu-x86_64, git desc: v6.6-rc1-33-g3669558bdf35
- linux-stable-rc-linux-4.14.y: qemu-armv7, git desc: v4.14.325-121-g5d7084c94bb1
- linux-stable-rc-linux-4.14.y: qemu-arm64, git desc: v4.14.325-121-g5d7084c94bb1
- linux-stable-rc-linux-4.14.y: qemu-i386, git desc: v4.14.325-121-g5d7084c94bb1
- linux-stable-rc-linux-4.14.y: qemu-x86_64, git desc: v4.14.325-121-g5d7084c94bb1
- linux-stable-rc-linux-4.19.y: qemu-armv7, git desc: v4.19.294-196-g0d1f84224483
- linux-stable-rc-linux-4.19.y: qemu-arm64, git desc: v4.19.294-196-g0d1f84224483
- linux-stable-rc-linux-4.19.y: qemu-i386, git desc: v4.19.294-196-g0d1f84224483
- linux-stable-rc-linux-4.19.y: qemu-x86_64, git desc: v4.19.294-196-g0d1f84224483
- linux-stable-rc-linux-5.10.y: qemu-armv7, git desc: v5.10.194-314-geea281d7b56d
- linux-stable-rc-linux-5.10.y: qemu-arm64, git desc: v5.10.194-314-geea281d7b56d
- linux-stable-rc-linux-5.10.y: qemu-i386, git desc: v5.10.194-314-geea281d7b56d
- linux-stable-rc-linux-5.10.y: qemu-x86_64, git desc: v5.10.194-314-geea281d7b56d
- linux-stable-rc-linux-5.15.y: qemu-armv7, git desc: v5.15.131-378-g61dc41f49c69
- linux-stable-rc-linux-5.15.y: qemu-arm64, git desc: v5.15.131-378-g61dc41f49c69
- linux-stable-rc-linux-5.15.y: qemu-i386, git desc: v5.15.131-378-g61dc41f49c69
- linux-stable-rc-linux-5.15.y: qemu-x86_64, git desc: v5.15.131-378-g61dc41f49c69
- linux-stable-rc-linux-6.1.y: qemu-armv7, git desc: v6.1.52-601-g6e71673725ca
- linux-stable-rc-linux-6.1.y: qemu-arm64, git desc: v6.1.52-601-g6e71673725ca
- linux-stable-rc-linux-6.1.y: qemu-i386, git desc: v6.1.52-601-g6e71673725ca
- linux-stable-rc-linux-6.1.y: qemu-x86_64, git desc: v6.1.52-601-g6e71673725ca