### PR TITLE
[automated] automated: linux: ltp: skipfile: remove perf_event_open02

### DIFF
--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -274,10 +274,6 @@ skiplist:
       - qemu_arm64
       - qemu_x86_64
       - qemu_i386
-      - qemu-armv7
-      - qemu-arm64
-      - qemu-x86_64
-      - qemu-i386
       - fvp-aemva
 
     branches: all


### PR DESCRIPTION
[automated] Updates to skipfile to remove:

- perf_event_open02

Test were shown to pass/fail rather than hang do not need to be skipped.

Remove for devices:

- qemu-i386
- qemu-arm64
- qemu-armv7
- qemu-x86_64

Tests run 10 time(s) per device.

Tested on:

- linux-next-master: qemu-armv7, git desc: next-20230915, build_name: gcc-13-lkftconfig
- linux-next-master: qemu-arm64, git desc: next-20230915, build_name: gcc-13-lkftconfig
- linux-next-master: qemu-i386, git desc: next-20230915, build_name: gcc-13-lkftconfig
- linux-next-master: qemu-x86_64, git desc: next-20230915, build_name: gcc-13-lkftconfig
- linux-mainline-master: qemu-armv7, git desc: v6.6-rc1-115-g9fdfb15a3dbf, build_name: gcc-13-lkftconfig
- linux-mainline-master: qemu-arm64, git desc: v6.6-rc1-115-g9fdfb15a3dbf, build_name: gcc-13-lkftconfig
- linux-mainline-master: qemu-i386, git desc: v6.6-rc1-115-g9fdfb15a3dbf, build_name: gcc-13-lkftconfig
- linux-mainline-master: qemu-x86_64, git desc: v6.6-rc1-115-g9fdfb15a3dbf, build_name: gcc-13-lkftconfig
- linux-stable-rc-linux-4.14.y: qemu-armv7, git desc: v4.14.325-121-g5d7084c94bb1, build_name: gcc-12-lkftconfig
- linux-stable-rc-linux-4.14.y: qemu-arm64, git desc: v4.14.325-121-g5d7084c94bb1, build_name: gcc-12-lkftconfig
- linux-stable-rc-linux-4.14.y: qemu-i386, git desc: v4.14.325-121-g5d7084c94bb1, build_name: gcc-12-lkftconfig
- linux-stable-rc-linux-4.14.y: qemu-x86_64, git desc: v4.14.325-121-g5d7084c94bb1, build_name: gcc-12-lkftconfig
- linux-stable-rc-linux-4.19.y: qemu-armv7, git desc: v4.19.294-196-g0d1f84224483, build_name: gcc-12-lkftconfig
- linux-stable-rc-linux-4.19.y: qemu-arm64, git desc: v4.19.294-196-g0d1f84224483, build_name: gcc-12-lkftconfig
- linux-stable-rc-linux-4.19.y: qemu-i386, git desc: v4.19.294-196-g0d1f84224483, build_name: gcc-12-lkftconfig
- linux-stable-rc-linux-4.19.y: qemu-x86_64, git desc: v4.19.294-196-g0d1f84224483, build_name: gcc-12-lkftconfig
- linux-stable-rc-linux-5.10.y: qemu-armv7, git desc: v5.10.194-314-geea281d7b56d, build_name: gcc-12-lkftconfig
- linux-stable-rc-linux-5.10.y: qemu-arm64, git desc: v5.10.194-314-geea281d7b56d, build_name: gcc-12-lkftconfig
- linux-stable-rc-linux-5.10.y: qemu-i386, git desc: v5.10.194-314-geea281d7b56d, build_name: gcc-12-lkftconfig
- linux-stable-rc-linux-5.10.y: qemu-x86_64, git desc: v5.10.194-314-geea281d7b56d, build_name: gcc-12-lkftconfig
- linux-stable-rc-linux-5.15.y: qemu-armv7, git desc: v5.15.131-378-g61dc41f49c69, build_name: gcc-12-lkftconfig
- linux-stable-rc-linux-5.15.y: qemu-arm64, git desc: v5.15.131-378-g61dc41f49c69, build_name: gcc-12-lkftconfig
- linux-stable-rc-linux-5.15.y: qemu-i386, git desc: v5.15.131-378-g61dc41f49c69, build_name: gcc-12-lkftconfig
- linux-stable-rc-linux-5.15.y: qemu-x86_64, git desc: v5.15.131-378-g61dc41f49c69, build_name: gcc-12-lkftconfig
- linux-stable-rc-linux-6.1.y: qemu-armv7, git desc: v6.1.52-601-g6e71673725ca, build_name: gcc-13-lkftconfig
- linux-stable-rc-linux-6.1.y: qemu-arm64, git desc: v6.1.52-601-g6e71673725ca, build_name: gcc-13-lkftconfig
- linux-stable-rc-linux-6.1.y: qemu-i386, git desc: v6.1.52-601-g6e71673725ca, build_name: gcc-13-lkftconfig
- linux-stable-rc-linux-6.1.y: qemu-x86_64, git desc: v6.1.52-601-g6e71673725ca, build_name: gcc-13-lkftconfig

SQUAD build URLs:
- linux-mainline-master: https://qa-reports.linaro.org/api/builds/163592/
- linux-next-master: https://qa-reports.linaro.org/api/builds/163593/
- linux-4.14.y: https://qa-reports.linaro.org/api/builds/163594/
- linux-4.19.y: https://qa-reports.linaro.org/api/builds/163595/
- linux-5.10.y: https://qa-reports.linaro.org/api/builds/163596/
- linux-5.15.y: https://qa-reports.linaro.org/api/builds/163597/
- linux-6.1.y: https://qa-reports.linaro.org/api/builds/163598/