### PR TITLE
[automated] automated: linux: ltp: skipfile: remove msgctl10,msgctl11,msgstress03,msgstress04

### DIFF
--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -97,7 +97,6 @@ skiplist:
       - qemu-armv7
       - qemu-arm64
       - qemu-x86_64
-      - qemu-i386
       - fvp-aemva
 
     branches: all


### PR DESCRIPTION
[automated] Updates to skipfile to remove:

- msgctl10
- msgctl11
- msgstress03
- msgstress04

Test were shown to pass/fail rather than hang do not need to be skipped.

Remove for devices:

- qemu-i386

Tests run 5 time(s) per device.

Tested on:
project: device, git_desc, build_name
- linux-next-master: qemu-armv7, next-20230915, gcc-13-lkftconfig
- linux-next-master: qemu-arm64, next-20230915, gcc-13-lkftconfig
- linux-next-master: qemu-i386, next-20230915, gcc-13-lkftconfig
- linux-next-master: qemu-x86_64, next-20230915, gcc-13-lkftconfig
- linux-mainline-master: qemu-armv7, v6.6-rc2, gcc-13-lkftconfig
- linux-mainline-master: qemu-arm64, v6.6-rc2, gcc-13-lkftconfig
- linux-mainline-master: qemu-i386, v6.6-rc2, gcc-13-lkftconfig
- linux-mainline-master: qemu-x86_64, v6.6-rc2, gcc-13-lkftconfig
- linux-stable-rc-linux-4.14.y: qemu-armv7, v4.14.325-148-gab7b4df76cff, gcc-12-lkftconfig
- linux-stable-rc-linux-4.14.y: qemu-arm64, v4.14.325-148-gab7b4df76cff, gcc-12-lkftconfig
- linux-stable-rc-linux-4.14.y: qemu-i386, v4.14.325-148-gab7b4df76cff, gcc-12-lkftconfig
- linux-stable-rc-linux-4.14.y: qemu-x86_64, v4.14.325-148-gab7b4df76cff, gcc-12-lkftconfig
- linux-stable-rc-linux-4.19.y: qemu-armv7, v4.19.294-235-gf91592b50ab2, gcc-12-lkftconfig
- linux-stable-rc-linux-4.19.y: qemu-arm64, v4.19.294-235-gf91592b50ab2, gcc-12-lkftconfig
- linux-stable-rc-linux-4.19.y: qemu-i386, v4.19.294-235-gf91592b50ab2, gcc-12-lkftconfig
- linux-stable-rc-linux-4.19.y: qemu-x86_64, v4.19.294-235-gf91592b50ab2, gcc-12-lkftconfig
- linux-stable-rc-linux-5.10.y: qemu-armv7, v5.10.194-407-g794568ce435b, gcc-12-lkftconfig
- linux-stable-rc-linux-5.10.y: qemu-arm64, v5.10.194-407-g794568ce435b, gcc-12-lkftconfig
- linux-stable-rc-linux-5.10.y: qemu-i386, v5.10.194-407-g794568ce435b, gcc-12-lkftconfig
- linux-stable-rc-linux-5.10.y: qemu-x86_64, v5.10.194-407-g794568ce435b, gcc-12-lkftconfig
- linux-stable-rc-linux-5.15.y: qemu-armv7, v5.15.131-512-ga8d93816a2f2, gcc-12-lkftconfig
- linux-stable-rc-linux-5.15.y: qemu-arm64, v5.15.131-512-ga8d93816a2f2, gcc-12-lkftconfig
- linux-stable-rc-linux-5.15.y: qemu-i386, v5.15.131-512-ga8d93816a2f2, gcc-12-lkftconfig
- linux-stable-rc-linux-5.15.y: qemu-x86_64, v5.15.131-512-ga8d93816a2f2, gcc-12-lkftconfig
- linux-stable-rc-linux-6.1.y: qemu-armv7, v6.1.52-813-g89fc7c511aa5, gcc-13-lkftconfig
- linux-stable-rc-linux-6.1.y: qemu-arm64, v6.1.52-813-g89fc7c511aa5, gcc-13-lkftconfig
- linux-stable-rc-linux-6.1.y: qemu-i386, v6.1.52-813-g89fc7c511aa5, gcc-13-lkftconfig
- linux-stable-rc-linux-6.1.y: qemu-x86_64, v6.1.52-813-g89fc7c511aa5, gcc-13-lkftconfig

SQUAD build URLs:
- linux-mainline-master: https://qa-reports.linaro.org/api/builds/163821/
- linux-next-master: https://qa-reports.linaro.org/api/builds/163822/
- linux-4.14.y: https://qa-reports.linaro.org/api/builds/163823/
- linux-4.19.y: https://qa-reports.linaro.org/api/builds/163824/
- linux-5.10.y: https://qa-reports.linaro.org/api/builds/163825/
- linux-5.15.y: https://qa-reports.linaro.org/api/builds/163826/
- linux-6.1.y: https://qa-reports.linaro.org/api/builds/163827/