### PR TITLE
[automated] automated: linux: ltp: skipfile: remove ping602

### DIFF
--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -678,10 +678,6 @@ skiplist:
       - qemu_arm64
       - qemu_x86_64
       - qemu_i386
-      - qemu-armv7
-      - qemu-arm64
-      - qemu-x86_64
-      - qemu-i386
       - fvp-aemva
 
     branches:


### PR DESCRIPTION
[automated] Updates to skipfile to remove:

- ping602

Tests did not hang so do not need to be skipped.

Remove for devices:

- qemu-i386
- qemu-armv7
- qemu-x86_64
- qemu-arm64

Tests run 1 time(s) per device.

Tested on:
project: device, git_desc, build_name
- linux-stable-rc-linux-6.1.y: qemu-armv7, v6.1.55, gcc-13-lkftconfig
- linux-stable-rc-linux-6.1.y: qemu-arm64, v6.1.55, gcc-13-lkftconfig
- linux-stable-rc-linux-6.1.y: qemu-i386, v6.1.55, gcc-13-lkftconfig
- linux-stable-rc-linux-6.1.y: qemu-x86_64, v6.1.55, gcc-13-lkftconfig

SQUAD build URLs:
- linux-6.1.y: https://qa-reports.linaro.org/api/builds/164625/