### PR TITLE
[automated] automated: linux: ltp: skipfile: remove ftrace_stress_test.sh

### DIFF
--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -647,10 +647,6 @@ skiplist:
       - qemu_arm64
       - qemu_x86_64
       - qemu_i386
-      - qemu-armv7
-      - qemu-arm64
-      - qemu-x86_64
-      - qemu-i386
       - fvp-aemva
 
     branches:


### PR DESCRIPTION
[automated] Updates to skipfile to remove:

- ftrace_stress_test.sh

Tests did not hang so do not need to be skipped.

Remove for devices:

- qemu-arm64
- qemu-i386
- qemu-armv7
- qemu-x86_64

Tests run 3 time(s) per device.

Tested on:
project: device, git_desc, build_name
- linux-next-master: qemu-armv7, next-20231004, gcc-13-lkftconfig
- linux-next-master: qemu-arm64, next-20231004, gcc-13-lkftconfig
- linux-next-master: qemu-i386, next-20231004, gcc-13-lkftconfig
- linux-next-master: qemu-x86_64, next-20231004, gcc-13-lkftconfig
- linux-stable-rc-linux-4.14.y: qemu-armv7, v4.14.326, gcc-12-lkftconfig
- linux-stable-rc-linux-4.14.y: qemu-arm64, v4.14.326, gcc-12-lkftconfig
- linux-stable-rc-linux-4.14.y: qemu-i386, v4.14.326, gcc-12-lkftconfig
- linux-stable-rc-linux-4.14.y: qemu-x86_64, v4.14.326, gcc-12-lkftconfig
- linux-stable-rc-linux-4.19.y: qemu-armv7, v4.19.295, gcc-12-lkftconfig
- linux-stable-rc-linux-4.19.y: qemu-arm64, v4.19.295, gcc-12-lkftconfig
- linux-stable-rc-linux-4.19.y: qemu-i386, v4.19.295, gcc-12-lkftconfig
- linux-stable-rc-linux-4.19.y: qemu-x86_64, v4.19.295, gcc-12-lkftconfig
- linux-stable-rc-linux-5.10.y: qemu-armv7, v5.10.197, gcc-12-lkftconfig
- linux-stable-rc-linux-5.10.y: qemu-arm64, v5.10.197, gcc-12-lkftconfig
- linux-stable-rc-linux-5.10.y: qemu-i386, v5.10.197, gcc-12-lkftconfig
- linux-stable-rc-linux-5.10.y: qemu-x86_64, v5.10.197, gcc-12-lkftconfig
- linux-stable-rc-linux-5.15.y: qemu-armv7, v5.15.133, gcc-12-lkftconfig
- linux-stable-rc-linux-5.15.y: qemu-arm64, v5.15.133, gcc-12-lkftconfig
- linux-stable-rc-linux-5.15.y: qemu-i386, v5.15.133, gcc-12-lkftconfig
- linux-stable-rc-linux-5.15.y: qemu-x86_64, v5.15.133, gcc-12-lkftconfig
- linux-stable-rc-linux-6.1.y: qemu-armv7, v6.1.55, gcc-13-lkftconfig
- linux-stable-rc-linux-6.1.y: qemu-arm64, v6.1.55, gcc-13-lkftconfig
- linux-stable-rc-linux-6.1.y: qemu-i386, v6.1.55, gcc-13-lkftconfig
- linux-stable-rc-linux-6.1.y: qemu-x86_64, v6.1.55, gcc-13-lkftconfig

SQUAD build URLs:
- linux-next-master: https://qa-reports.linaro.org/api/builds/164638/
- linux-4.14.y: https://qa-reports.linaro.org/api/builds/164639/
- linux-4.19.y: https://qa-reports.linaro.org/api/builds/164640/
- linux-5.10.y: https://qa-reports.linaro.org/api/builds/164641/
- linux-5.15.y: https://qa-reports.linaro.org/api/builds/164642/
- linux-6.1.y: https://qa-reports.linaro.org/api/builds/164643/