### PR TITLE
[automated] automated: linux: ltp: skipfile: remove ksm01

### DIFF
--- a/automated/linux/ltp/skipfile-lkft.yaml
+++ b/automated/linux/ltp/skipfile-lkft.yaml
@@ -454,9 +454,6 @@ skiplist:
       - qemu_arm64
       - qemu_x86_64
       - qemu_i386
-      - qemu-armv7
-      - qemu-arm64
-      - qemu-x86_64
       - qemu-i386
       - fvp-aemva
 


### PR DESCRIPTION
[automated] Updates to skipfile to remove:

- ksm01

Tests did not hang so do not need to be skipped.

Remove for devices:

- qemu-x86_64
- qemu-arm64
- qemu-armv7

Tests run 3 time(s) per device.

Tested on:
project: device, git_desc, build_name
- linux-mainline-master: qemu-armv7, v6.6-rc5, gcc-13-lkftconfig
- linux-mainline-master: qemu-arm64, v6.6-rc5, gcc-13-lkftconfig
- linux-mainline-master: qemu-i386, v6.6-rc5, gcc-13-lkftconfig
- linux-mainline-master: qemu-x86_64, v6.6-rc5, gcc-13-lkftconfig
- linux-next-master: qemu-armv7, next-20231009, gcc-13-lkftconfig
- linux-next-master: qemu-arm64, next-20231009, gcc-13-lkftconfig
- linux-next-master: qemu-i386, next-20231009, gcc-13-lkftconfig
- linux-next-master: qemu-x86_64, next-20231009, gcc-13-lkftconfig
- linux-stable-rc-linux-4.14.y: qemu-armv7, v4.14.326-31-g40fbbd42a05b, gcc-12-lkftconfig
- linux-stable-rc-linux-4.14.y: qemu-arm64, v4.14.326-31-g40fbbd42a05b, gcc-12-lkftconfig
- linux-stable-rc-linux-4.14.y: qemu-i386, v4.14.326-31-g40fbbd42a05b, gcc-12-lkftconfig
- linux-stable-rc-linux-4.14.y: qemu-x86_64, v4.14.326-31-g40fbbd42a05b, gcc-12-lkftconfig
- linux-stable-rc-linux-4.19.y: qemu-armv7, v4.19.295-67-ga70e2840d249, gcc-12-lkftconfig
- linux-stable-rc-linux-4.19.y: qemu-arm64, v4.19.295-67-ga70e2840d249, gcc-12-lkftconfig
- linux-stable-rc-linux-4.19.y: qemu-i386, v4.19.295-67-ga70e2840d249, gcc-12-lkftconfig
- linux-stable-rc-linux-4.19.y: qemu-x86_64, v4.19.295-67-ga70e2840d249, gcc-12-lkftconfig
- linux-stable-rc-linux-5.10.y: qemu-armv7, v5.10.197-168-g3eccb060a778, gcc-12-lkftconfig
- linux-stable-rc-linux-5.10.y: qemu-arm64, v5.10.197-168-g3eccb060a778, gcc-12-lkftconfig
- linux-stable-rc-linux-5.10.y: qemu-i386, v5.10.197-168-g3eccb060a778, gcc-12-lkftconfig
- linux-stable-rc-linux-5.10.y: qemu-x86_64, v5.10.197-168-g3eccb060a778, gcc-12-lkftconfig
- linux-stable-rc-linux-5.15.y: qemu-armv7, v5.15.134, gcc-12-lkftconfig
- linux-stable-rc-linux-5.15.y: qemu-arm64, v5.15.134, gcc-12-lkftconfig
- linux-stable-rc-linux-5.15.y: qemu-i386, v5.15.134, gcc-12-lkftconfig
- linux-stable-rc-linux-5.15.y: qemu-x86_64, v5.15.134, gcc-12-lkftconfig
- linux-stable-rc-linux-6.1.y: qemu-armv7, v6.1.56, gcc-13-lkftconfig
- linux-stable-rc-linux-6.1.y: qemu-arm64, v6.1.56, gcc-13-lkftconfig
- linux-stable-rc-linux-6.1.y: qemu-i386, v6.1.56, gcc-13-lkftconfig
- linux-stable-rc-linux-6.1.y: qemu-x86_64, v6.1.56, gcc-13-lkftconfig

SQUAD build URLs:
- linux-mainline-master: https://qa-reports.linaro.org/api/builds/164857/
- linux-next-master: https://qa-reports.linaro.org/api/builds/164858/
- linux-4.14.y: https://qa-reports.linaro.org/api/builds/164859/
- linux-4.19.y: https://qa-reports.linaro.org/api/builds/164860/
- linux-5.10.y: https://qa-reports.linaro.org/api/builds/164861/
- linux-5.15.y: https://qa-reports.linaro.org/api/builds/164862/
- linux-6.1.y: https://qa-reports.linaro.org/api/builds/164863/